### PR TITLE
Reduce memory usage of multipart uploader

### DIFF
--- a/src/SimpleS3.Core.Tests/Code/Other/NonSeekableStream.cs
+++ b/src/SimpleS3.Core.Tests/Code/Other/NonSeekableStream.cs
@@ -40,7 +40,7 @@ namespace Genbox.SimpleS3.Core.Tests.Code.Other
         public override bool CanRead => true;
         public override bool CanSeek => false;
         public override bool CanWrite => false;
-        public override long Length => throw new NotSupportedException();
+        public override long Length => _backingStream.Length;
 
         public override long Position
         {

--- a/src/SimpleS3.Core/Internals/Extensions/StreamExtensions.cs
+++ b/src/SimpleS3.Core/Internals/Extensions/StreamExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Genbox.SimpleS3.Core.Internals.Extensions
 {
@@ -11,6 +13,25 @@ namespace Genbox.SimpleS3.Core.Internals.Extensions
             while (count > 0)
             {
                 int numRead = stream.Read(buffer, offset, count);
+
+                if (numRead == 0)
+                    break;
+
+                offset += numRead;
+                count -= numRead;
+                totalRead += numRead;
+            }
+
+            return totalRead;
+        }
+
+        public static async Task<int> ReadUpToAsync(this Stream stream, byte[] buffer, int offset, int count, CancellationToken token = default)
+        {
+            int totalRead = 0;
+
+            while (count > 0)
+            {
+                int numRead = await stream.ReadAsync(buffer, offset, count, token).ConfigureAwait(false);
 
                 if (numRead == 0)
                     break;

--- a/src/SimpleS3.Core/Internals/Extensions/StreamExtensions.cs
+++ b/src/SimpleS3.Core/Internals/Extensions/StreamExtensions.cs
@@ -6,25 +6,6 @@ namespace Genbox.SimpleS3.Core.Internals.Extensions
 {
     internal static class StreamExtensions
     {
-        public static int ReadUpTo(this Stream stream, byte[] buffer, int offset, int count)
-        {
-            int totalRead = 0;
-
-            while (count > 0)
-            {
-                int numRead = stream.Read(buffer, offset, count);
-
-                if (numRead == 0)
-                    break;
-
-                offset += numRead;
-                count -= numRead;
-                totalRead += numRead;
-            }
-
-            return totalRead;
-        }
-
         public static async Task<int> ReadUpToAsync(this Stream stream, byte[] buffer, int offset, int count, CancellationToken token = default)
         {
             int totalRead = 0;


### PR DESCRIPTION
Ensure MultipartHelper doesn't cache the entire stream to be uploaded, in the `Queue<Task<GetObjectResponse>> queue` value.

~~Still needs fixing of Read bug (Read doesn't guarantee count bytes read). Parts may be partial.~~