### PR TITLE
Ensure IRequestStreamWrapper are added as enumerable

### DIFF
--- a/src/SimpleS3.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SimpleS3.Core/Extensions/ServiceCollectionExtensions.cs
@@ -66,7 +66,6 @@ namespace Genbox.SimpleS3.Core.Extensions
             collection.TryAddSingleton<IScopeBuilder, ScopeBuilder>();
             collection.TryAddSingleton<ISignatureBuilder, SignatureBuilder>();
             collection.TryAddSingleton<IChunkedSignatureBuilder, ChunkedSignatureBuilder>();
-            collection.TryAddSingleton<IRequestStreamWrapper, ChunkedContentRequestStreamWrapper>();
             collection.TryAddSingleton<HeaderAuthorizationBuilder>();
             collection.TryAddSingleton<QueryParameterAuthorizationBuilder>();
             collection.TryAddSingleton<IObjectOperations, ObjectOperations>();
@@ -79,6 +78,8 @@ namespace Genbox.SimpleS3.Core.Extensions
             collection.TryAddSingleton<IValidatorFactory, ValidatorFactory>();
             collection.TryAddSingleton<IMarshalFactory, MarshalFactory>();
             collection.TryAddSingleton<Transfer>();
+            
+            collection.AddSingleton<IRequestStreamWrapper, ChunkedContentRequestStreamWrapper>();
 
             Assembly assembly = typeof(S3Config).Assembly; //Needs to be the assembly that contains the types
 

--- a/src/SimpleS3.Extensions.HttpClientFactory.Polly/Extensions/HttpClientBuilderExtensions.cs
+++ b/src/SimpleS3.Extensions.HttpClientFactory.Polly/Extensions/HttpClientBuilderExtensions.cs
@@ -59,7 +59,7 @@ namespace Genbox.SimpleS3.Extensions.HttpClientFactory.Polly.Extensions
                 .WaitAndRetryAsync(retries, retryAttempt => backoffTime(retryAttempt));
 
             builder.AddPolicyHandler(exceptionPolicy);
-            builder.Services.TryAddSingleton<IRequestStreamWrapper, RetryableBufferingStreamWrapper>();
+            builder.Services.AddSingleton<IRequestStreamWrapper, RetryableBufferingStreamWrapper>();
             return builder;
         }
 


### PR DESCRIPTION
Turns out we missed the (beautiful) `RetryableBufferingStreamWrapper` as it was a `TryAdd*` call